### PR TITLE
Fix syntax highlighting due to unfortunate arg. name

### DIFF
--- a/dbrow3.cfc
+++ b/dbrow3.cfc
@@ -250,7 +250,7 @@
 
 		<cfset v.newRule = structNew()>
 		<cfset v.newRule.regex = arguments.regex>
-		<cfset v.newRule.function = arguments.function>
+		<cfset v.newRule['function'] = arguments['function']>
 		<cfset v.newRule.errorText = arguments.errorText>
 
 		<!--- Create stCustomValidation if it doesn't exist yet. - leon 4/21/08 --->
@@ -759,8 +759,8 @@
 									<cfset arrayAppend(v.arErrors, newError(v.thisProp, getLabel(v.thisProp), v.stRule.errorText))>
 								</cfif>
 							</cfif>
-							<cfif len(v.stRule.function)>
-								<cfif not(evaluate('#v.stRule.function#("#this[v.thisProp]#")'))>
+							<cfif Len(v.stRule['function'])>
+								<cfif NOT Evaluate('#v.stRule["function"]#("#this[v.thisProp]#")')>
 									<cfset arrayAppend(v.arErrors, newError(v.thisProp, getLabel(v.thisProp), v.stRule.errorText))>
 								</cfif>
 							</cfif>

--- a/test/index.cfm
+++ b/test/index.cfm
@@ -3,7 +3,8 @@
 
 testSuite = createObject("component","mxunit.framework.TestSuite").TestSuite();
 
-unitTestCFCs = ['instantiation_test', 'load_test', 'label_test',
+unitTestCFCs = ['addValidation_test', 'instantiation_test',
+	'load_test', 'label_test',
 	'drawForm_test', 'drawFormField_test', 'drawPropertyValue_test',
 	'drawStandardFormField_test', 'edit_test', 'formValidation_test'];
 

--- a/test/units/dbrow/addValidation_test.cfc
+++ b/test/units/dbrow/addValidation_test.cfc
@@ -1,0 +1,18 @@
+<cfcomponent extends="dbrow.test.units.abstract_testcase">
+<cfscript>
+
+public void function setUp() {
+  arthropod = arthropod_factory.create();
+}
+
+/* `addValidation` should store function name in `stCustomValidation` -Jared 2013 */
+public void function should_store_fn_name() {
+  arthropod.addValidation(argumentCollection = {
+    'propertyName' = 'arthropod_name', 'function' = 'foobar', 'errorText' = 'derp'
+  });
+  var actual = arthropod.stCustomValidation['arthropod_name'][1]['function'];
+  assertEquals('foobar', actual);
+}
+
+</cfscript>
+</cfcomponent>


### PR DESCRIPTION
Thankfully, I was able to fix the issue without changing the method signature.
