### PR TITLE
isValid('integer') doesn't work correctly for large values, so use a regex instead

### DIFF
--- a/dbrow3.cfc
+++ b/dbrow3.cfc
@@ -724,7 +724,7 @@
 							</cfif>
 						</cfcase>
 						<cfcase value="integer,bigint" delimiters=",">
-							<cfif not(isValid('integer', this[v.thisProp]))>
+							<cfif not REFind('^\d+$', this[v.thisProp])>
 								<cfset arrayAppend(v.arErrors, newError(v.thisProp, getLabel(v.thisProp), 'must be an integer'))>
 							</cfif>
 						</cfcase>


### PR DESCRIPTION
E.g. isValid('integer', 1234567890) => true,
 but isValid('integer', 12345678901) => false