### PR TITLE
Add PGSQL jsonb support

### DIFF
--- a/dbrow3_pgsql.cfc
+++ b/dbrow3_pgsql.cfc
@@ -119,6 +119,7 @@
 				case "double precision" : return "float"; break;
 				case "integer" : return "integer"; break;
 				case "json" : return "json"; break;
+				case "jsonb" : return "json"; break;
 				case "money" : return "decimal"; break;
 				case "numeric" : return "decimal"; break;
 				case "real" : return "float"; break;


### PR DESCRIPTION
`json` and `jsonb` only differ in how the database processes them internally. See: https://www.postgresql.org/docs/current/datatype-json.html